### PR TITLE
Update Dockerfile: Smaller image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER erkan yanar <erkan.yanar@linsenraum.de>
 ENV VERSION 20170605
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get install -y  software-properties-common && \
-    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 BC19DDBA && \
-    add-apt-repository 'deb http://releases.galeracluster.com/ubuntu xenial main' && \
+RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 BC19DDBA && \
+    echo 'deb http://releases.galeracluster.com/ubuntu xenial main' > /etc/apt/sources.list.d/galeracluster.list && \
     apt-get update && \
     apt-get install -y galera-3 galera-arbitrator-3 mysql-wsrep-5.6 rsync lsof
 RUN rm -r /var/lib/mysql


### PR DESCRIPTION
Removing the installation of software-properties-common package makes for a smaller Docker image.  Additional changes can be made for even smaller images, but this is the least disruptive.